### PR TITLE
travis support and fix tests using reduce in Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+script: nosetests

--- a/functional/chain.py
+++ b/functional/chain.py
@@ -1,4 +1,5 @@
 import collections
+from functools import reduce
 
 
 class FunctionalSequence(object):


### PR DESCRIPTION
You just need to log in to Travis and turn it on for the repository. You can also add the Travis badge to the README. The results are generated both for Python 2 and Python 3, you can see example on my branch: https://travis-ci.org/adrian17/ScalaFunctional/builds/53798861

Currently two tests fail on Python 3.