### PR TITLE
implemented init, inits, tails; added docstrings

### DIFF
--- a/functional/chain.py
+++ b/functional/chain.py
@@ -120,10 +120,58 @@ class FunctionalSequence(object):
         return self.head()
 
     def last(self):
+        """
+        Returns the last element of the sequence.
+
+        >>> seq([1, 2, 3]).last()
+        3
+
+        Raises IndexError when the sequence is empty.
+
+        >>> seq([]).last()
+        Traceback (most recent call last):
+         ...
+        IndexError: list index out of range
+        """
         return _wrap(self.sequence[-1])
 
+    def init(self):
+        """
+        Returns the sequence, without its last element.
+
+        >>> seq([1, 2, 3]).init()
+        [1, 2]
+        """
+        return FunctionalSequence(self.sequence[:-1])
+
     def tail(self):
+        """
+        Returns the sequence, without its first element.
+
+        >>> seq([1, 2, 3]).init()
+        [2, 3]
+        """
         return FunctionalSequence(self.sequence[1:])
+
+    def inits(self):
+        """
+        Returns consecutive inits of the sequence.
+
+        >>> seq([1, 2, 3]).inits()
+        [[1, 2, 3], [1, 2], [1], []]
+        """
+        result = [_wrap(self.sequence[:i]) for i in reversed(range(len(self.sequence)+1))]
+        return FunctionalSequence(result)
+
+    def tails(self):
+        """
+        Returns consecutive tails of the sequence.
+
+        >>> seq([1, 2, 3]).tails()
+        [[1, 2, 3], [2, 3], [3], []]
+        """
+        result = [_wrap(self.sequence[i:]) for i in range(len(self.sequence)+1)]
+        return FunctionalSequence(result)
 
     def drop(self, n):
         return FunctionalSequence(self.sequence[n:])

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -130,10 +130,27 @@ class TestChain(unittest.TestCase):
         self.assertEqual(l.last(), [3, 4])
         self.assertType(l.last())
 
+    def test_init(self):
+        l = seq([1, 2, 3, 4])
+        expect = [1, 2, 3]
+        self.assertSequenceEqual(l.init(), expect)
+
     def test_tail(self):
         l = seq([1, 2, 3, 4])
         expect = [2, 3, 4]
         self.assertSequenceEqual(l.tail(), expect)
+
+    def test_inits(self):
+        l = seq([1, 2, 3])
+        expect = [[1, 2, 3], [1, 2], [1], []]
+        self.assertSequenceEqual(l.inits(), expect)
+        self.assertEquals(l.inits().map(lambda s: s.sum()), [6, 3, 1, 0])
+
+    def test_tails(self):
+        l = seq([1, 2, 3])
+        expect = [[1, 2, 3], [2, 3], [3], []]
+        self.assertSequenceEqual(l.tails(), expect)
+        self.assertEquals(l.tails().map(lambda s: s.sum()), [6, 5, 3, 0])
 
     def test_drop(self):
         l = [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
Note that subsequences in `inits` and `tails` are wrapped; I thought that makes sense, as these functions AFAIK are rarely used on their own, and instead used in combination with `map` etc:

    seq([1, 2, 3, 4, 5, 6]).inits().map(lambda s: s.sum())

So the implicit wrap would make it more convenient.

Also, I couldn't just write the test like this:

    self.assertType(l.tails()[0])

because the subscript operator would wrap the result anyway.

Sorry for not using the `:return:` convention in docstrings, but I don't know what to write there without copying the description word for word.