### PR TITLE
Test on pypy2/3 plus irrelevant bug on tests discovered by the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ install:
 python:
   - "2.7"
   - "3.4"
+  - "pypy" 
+  - "pypy3" 
 script: nosetests --with-coverage --cover-package=functional
 after_success:
   - coveralls

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -222,25 +222,25 @@ class TestChain(unittest.TestCase):
         result = seq([1, 1, 2, 3, 3]).union([1, 4, 5])
         expect = [1, 2, 3, 4, 5]
         self.assert_type(result)
-        self.assertSequenceEqual(result, expect)
+        self.assertSetEqual(result.set(), set(expect))
 
     def test_intersection(self):
         result = seq([1, 2, 2, 3]).intersection([2, 3, 4, 5])
         expect = [2, 3]
         self.assert_type(result)
-        self.assertSequenceEqual(result, expect)
+        self.assertSetEqual(result.set(), set(expect))
 
     def test_difference(self):
         result = seq([1, 2, 3]).difference([2, 3, 4])
         expect = [1]
         self.assert_type(result)
-        self.assertSequenceEqual(result, expect)
+        self.assertSetEqual(result.set(), set(expect))
 
     def test_symmetric_difference(self):
         result = seq([1, 2, 3, 3]).symmetric_difference([2, 4, 5])
         expect = [1, 3, 4, 5]
         self.assert_type(result)
-        self.assertSequenceEqual(result, expect)
+        self.assertSetEqual(result.set(), set(expect))
 
     def test_map(self):
         f = lambda x: x * 2


### PR DESCRIPTION
Tests succeed on pypy2/3 (thus added to travis)
except for some tests on sets
that were accidentally written as deterministic.
(I fixed them in the same PR to keep the build clean)
___
By the way,
while `set(seq('abc'))` gives the expected in the shell,
in tests I get an empty set and can only use .the `set()` method.
Probably `assertSetEqual(result, set(expected))` doesn't work for the same reason.

Looks to me like a bug you may want to investigate.