### PR TITLE
Use absolute imports

### DIFF
--- a/functional/__init__.py
+++ b/functional/__init__.py
@@ -2,7 +2,9 @@
 Package for creating data pipelines, LINQ-style data analysis, and functional programming. Imports
 the primary entrypoint at streams.seq
 """
-from .streams import seq
+from __future__ import absolute_import
+
+from functional.streams import seq
 
 __author__ = "Pedro Rodriguez"
 __copyright__ = "Copyright 2015, Pedro Rodriguez"

--- a/functional/lineage.py
+++ b/functional/lineage.py
@@ -1,5 +1,7 @@
-from .transformations import CACHE_T
-from .transformations import ExecutionStrategies
+from __future__ import absolute_import
+
+from functional.transformations import CACHE_T
+from functional.transformations import ExecutionStrategies
 
 
 class Lineage(object):

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -4,7 +4,7 @@
 The pipeline module contains the primary data structure Sequence and entry point seq
 """
 
-from __future__ import division
+from __future__ import division, absolute_import
 from operator import mul
 import collections
 from functools import reduce
@@ -13,9 +13,9 @@ import json
 import csv
 import future.builtins as builtins
 
-from .lineage import Lineage
-from .util import is_iterable, is_primitive, identity, CSV_WRITE_MODE
-from . import transformations
+from functional.lineage import Lineage
+from functional.util import is_iterable, is_primitive, identity, CSV_WRITE_MODE
+from functional import transformations
 
 
 class Sequence(object):

--- a/functional/streams.py
+++ b/functional/streams.py
@@ -1,12 +1,13 @@
 # pylint: disable=redefined-builtin,too-many-arguments
+from __future__ import absolute_import
 
 import future.builtins as builtins
 import re
 import csv as csvapi
 import json as jsonapi
 import six
-from .pipeline import Sequence
-from .util import is_primitive, ReusableFile
+from functional.pipeline import Sequence
+from functional.util import is_primitive, ReusableFile
 
 
 def seq(*args):

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -1,10 +1,11 @@
 #pylint: skip-file
+from __future__ import absolute_import
 
 import unittest
 from collections import namedtuple
-from ..pipeline import Sequence, is_iterable, _wrap
-from ..transformations import name
-from .. import seq
+from functional.pipeline import Sequence, is_iterable, _wrap
+from functional.transformations import name
+from functional import seq
 
 Data = namedtuple('Data', 'x y')
 

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import unittest
 import six
-from .. import seq
+from functional import seq
 
 
 class TestStreams(unittest.TestCase):

--- a/functional/test/test_util.py
+++ b/functional/test/test_util.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
+
 import unittest
-from ..util import ReusableFile
+from functional.util import ReusableFile
 
 
 class TestUtil(unittest.TestCase):

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-builtin,missing-docstring,no-member,invalid-name
+from __future__ import absolute_import
 
 from future.builtins import map, filter, zip, range
 from functools import reduce, partial
@@ -8,7 +9,7 @@ import collections
 import types
 import six
 
-from .util import filterfalse
+from functional.util import filterfalse
 
 
 #: Defines a Transformation from a name, function, and execution_strategies

--- a/functional/util.py
+++ b/functional/util.py
@@ -1,5 +1,7 @@
 # pylint: disable=no-name-in-module,unused-import
 
+from __future__ import absolute_import
+
 import collections
 import six
 import future.builtins as builtins


### PR DESCRIPTION
Uses more explicit absolute imports and imports `absolute_import` for extra safety.

AFAIK should perfectly build on both Py2 and 3. I checked them on my OS, but let's see what CI has to say too.