### PR TITLE
Insert into sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ In addition to the aggregate functions shown above (`sum` and `max_by`) there ar
 Similarly, there are several more set like functions in addition to `difference`.
 
 ### Querying to SQLite3
-`Scalafunctional` can submit a SQL query SQLite3 database files. In `examples/users.db`, users are stored as rows with
+`Scalafunctional` can submit a SQL query to SQLite3 database files. In `examples/users.db`, users are stored as rows with
 columns `id:Int` and `name:String`. Below are examples of querying them through `seq.sqlite3`.
 
 ```python
@@ -181,7 +181,7 @@ sorted_users = seq.sqlite3(db_path, 'select * from users order by name;').to_lis
 
 
 ### Writing to files
-Just as `ScalaFunctional` can read from `csv`, `json`, `jsonl`, and text files, it can also write them. For complete API
+Just as `ScalaFunctional` can read from `csv`, `json`, `jsonl`, `sqlite3`, and text files, it can also write them. For complete API
 documentation see the collections API table or the official docs.
 
 
@@ -308,6 +308,7 @@ Function | Description | Type
 `to_csv(path)` | Saves the sequence to a csv file at path with each element representing a row | action
 `to_jsonl(path)` | Saves the sequence to a jsonl file with each element being transformed to json and printed to a new line | action
 `to_json(path)` | Saves the sequence to a json file. The contents depend on if the json root is an array or dictionary | action
+`to_sqlite3(conn, tablename_or_query, *args, **kwargs)` | Save the sequence to a SQLite3 db. The target table must be created in advance. | action
 `cache()` | Forces evaluation of sequence immediately and caches the result | action
 `for_each(func)` | Executes `func` on each element of the sequence | action
 

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1469,7 +1469,8 @@ class Sequence(object):
                 sql = 'INSERT INTO {} VALUES ({})'.format(table_name, placeholders)
                 conn.execute(sql, item)
             else:
-                raise TypeError('item must be either dict or namedtuple, got {}'.format(type(item)))
+                raise TypeError('item must be one of dict, namedtuple, tuple or list got {}'
+                                .format(type(item)))
 
         self.for_each(_insert_item)
 

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1477,9 +1477,11 @@ class Sequence(object):
         """
         Saves the sequence to sqlite3 database.
         Target table must be created in advance.
-        The table schema is inferred from the elements in the sequence if only target table name is supplied.
+        The table schema is inferred from the elements in the sequence
+        if only target table name is supplied.
 
-        >>> seq([(1, 'Tom'), (2, 'Jack')]).to_sqlite3('users.db', 'INSERT INTO user (id, name) VALUES (?, ?)')
+        >>> seq([(1, 'Tom'), (2, 'Jack')])\
+                .to_sqlite3('users.db', 'INSERT INTO user (id, name) VALUES (?, ?)')
 
         >>> seq([{'id': 1, 'name': 'Tom'}, {'id': 2, 'name': 'Jack'}]).to_sqlite3(conn, 'user')
 

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1460,7 +1460,7 @@ class Sequence(object):
                 sql = 'INSERT INTO {} ({}) VALUES ({})'.format(table_name, cols, placeholders)
                 conn.execute(sql, tuple(item.values()))
             elif is_namedtuple(item):
-                cols = ", ".join(item._fields)
+                cols = ', '.join(item._fields)
                 placeholders = ', '.join('?' * len(item))
                 sql = 'INSERT INTO {} ({}) VALUES ({})'.format(table_name, cols, placeholders)
                 conn.execute(sql, item)
@@ -1469,7 +1469,7 @@ class Sequence(object):
                 sql = 'INSERT INTO {} VALUES ({})'.format(table_name, placeholders)
                 conn.execute(sql, item)
             else:
-                raise TypeError("item must be either dict or namedtuple, got {}".format(type(item)))
+                raise TypeError('item must be either dict or namedtuple, got {}'.format(type(item)))
 
         self.for_each(_insert_item)
 

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1435,7 +1435,7 @@ class Sequence(object):
 
     def _to_sqlite3_by_query(self, conn, sql):
         """
-        Saves the sequence to sqlite3 database.
+        Saves the sequence to sqlite3 database by supplied query.
         Each element should be an iterable which will be expanded
         to the elements of each row. Target table must be created in advance.
 
@@ -1446,15 +1446,13 @@ class Sequence(object):
 
     def _to_sqlite3_by_table(self, conn, table_name):
         """
-        Saves the sequence to sqlite3 database.
-        Each element should be a dictionary whose key exists in the target table as as a column.
+        Saves the sequence to the specified table of sqlite3 database.
+        Each element can be a dictionary, namedtuple, tuple or list.
         Target table must be created in advance.
 
         :param conn: path or sqlite connection, cursor
         :param table_name: table name string
         """
-
-
         def _insert_item(item):
             if isinstance(item, dict):
                 cols = ', '.join(item.keys())
@@ -1473,7 +1471,6 @@ class Sequence(object):
             else:
                 raise TypeError("item must be either dict or namedtuple, got {}".format(type(item)))
 
-
         self.for_each(_insert_item)
 
     def to_sqlite3(self, conn, target, *args, **kwargs):
@@ -1488,10 +1485,8 @@ class Sequence(object):
         """
         insert_regex = re.compile(r'(insert|update)\s+into', flags=re.IGNORECASE)
         if insert_regex.match(target):
-            # target is an insertion sql query
             insert_f = self._to_sqlite3_by_query
         else:
-            # target is table name
             insert_f = self._to_sqlite3_by_table
 
         if isinstance(conn, (sqlite3.Connection, sqlite3.Cursor)):

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1477,6 +1477,11 @@ class Sequence(object):
         """
         Saves the sequence to sqlite3 database.
         Target table must be created in advance.
+        The table schema is inferred from the elements in the sequence if only target table name is supplied.
+
+        >>> seq([(1, 'Tom'), (2, 'Jack')]).to_sqlite3('users.db', 'INSERT INTO user (id, name) VALUES (?, ?)')
+
+        >>> seq([{'id': 1, 'name': 'Tom'}, {'id': 2, 'name': 'Jack'}]).to_sqlite3(conn, 'user')
 
         :param conn: path or sqlite connection, cursor
         :param target: SQL query string or table name

--- a/functional/streams.py
+++ b/functional/streams.py
@@ -180,7 +180,7 @@ def sqlite3(conn, sql, parameters=None, *args, **kwargs):
     Additional entry point to Sequence which query data from sqlite db file.
 
     >>> seq.sqlite3('examples/users.db', 'select id, name from users where id = 1;').first()
-    [(1, "Tom")]
+    [(1, 'Tom')]
 
     :param conn: path or sqlite connection, cursor
     :param sql: SQL query string

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import sqlite3
-import time
 import unittest
 import collections
 

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -173,14 +173,24 @@ class TestStreams(unittest.TestCase):
         os.remove(tmp_path)
 
     def test_to_sqlite3_connection(self):
+        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+
+        # test insert tuples into a connection
         with sqlite3.connect(":memory:") as conn:
             conn.execute("CREATE TABLE user (id INT, name TEXT);")
             conn.commit()
 
             insert_sql = "INSERT INTO user (id, name) VALUES (?, ?)"
-            elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
-
-            # test insert into a connection
             seq(elements).to_sqlite3(conn, insert_sql)
+            result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
+            self.assertListEqual(elements, result)
+
+        # test insert dicts into a connection
+        with sqlite3.connect(":memory:") as conn:
+            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+            conn.commit()
+
+            table_name = "user"
+            seq(elements).map(lambda x: {"id": x[0], "name": x[1]}).to_sqlite3(conn, table_name)
             result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
             self.assertListEqual(elements, result)

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -156,7 +156,8 @@ class TestStreams(unittest.TestCase):
 
     def test_to_sqlite3_file(self):
         tmp_path = 'functional/test/data/tmp/output.db'
-        os.remove(tmp_path)
+        if os.path.isfile(tmp_path):
+            os.remove(tmp_path)
 
         with sqlite3.connect(tmp_path) as conn:
             conn.execute("CREATE TABLE user (id INT, name TEXT);")
@@ -172,7 +173,8 @@ class TestStreams(unittest.TestCase):
 
     def test_to_sqlite3_connection(self):
         tmp_path = 'functional/test/data/tmp/output.db'
-        os.remove(tmp_path)
+        if os.path.isfile(tmp_path):
+            os.remove(tmp_path)
 
         with sqlite3.connect(tmp_path) as conn:
             conn.execute("CREATE TABLE user (id INT, name TEXT);")

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import os
 import sqlite3
 import time
 import unittest
@@ -157,9 +156,10 @@ class TestStreams(unittest.TestCase):
             seq(elements).to_sqlite3(1, insert_sql)
 
     def test_to_sqlite3_file(self):
-        tmp_path = 'functional/test/data/tmp/{}.db'.format(time.time())
+        tmp_path = 'functional/test/data/tmp/test.db'
 
         with sqlite3.connect(tmp_path) as conn:
+            conn.execute("DROP TABLE IF EXISTS user;")
             conn.execute("CREATE TABLE user (id INT, name TEXT);")
             conn.commit()
 
@@ -171,7 +171,6 @@ class TestStreams(unittest.TestCase):
         result = seq.sqlite3(tmp_path, "SELECT id, name FROM user;").to_list()
         self.assertListEqual(elements, result)
 
-        os.remove(tmp_path)
 
     def test_to_sqlite3_query(self):
         elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -70,12 +70,12 @@ class TestStreams(unittest.TestCase):
 
         # test failure case
         with self.assertRaises(ValueError):
-            seq.sqlite3(1, "SELECT * from user").to_list()
+            seq.sqlite3(1, 'SELECT * from user').to_list()
 
         # test select from file path
-        query_0 = "SELECT id, name FROM user;"
+        query_0 = 'SELECT id, name FROM user;'
         result_0 = seq.sqlite3(db_file, query_0).to_list()
-        expected_0 = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        expected_0 = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
         self.assertListEqual(expected_0, result_0)
 
         # test select from connection
@@ -95,15 +95,15 @@ class TestStreams(unittest.TestCase):
 
         # test order by
         result_1 = seq.sqlite3(db_file,
-                               "SELECT id, name FROM user ORDER BY name;").to_list()
-        expected_1 = [(2, "Jack"), (3, "Jane"), (4, "Stephan"), (1, "Tom")]
+                               'SELECT id, name FROM user ORDER BY name;').to_list()
+        expected_1 = [(2, 'Jack'), (3, 'Jane'), (4, 'Stephan'), (1, 'Tom')]
         self.assertListEqual(expected_1, result_1)
 
         # test query with params
         result_2 = seq.sqlite3(db_file,
-                               "SELECT id, name FROM user WHERE id = ?;",
+                               'SELECT id, name FROM user WHERE id = ?;',
                                parameters=(1,)).to_list()
-        expected_2 = [(1, "Tom")]
+        expected_2 = [(1, 'Tom')]
         self.assertListEqual(expected_2, result_2)
 
     def test_to_file(self):
@@ -113,7 +113,7 @@ class TestStreams(unittest.TestCase):
         with open(tmp_path, 'r') as output:
             self.assertEqual('[1, 2, 3, 4]', output.readlines()[0])
 
-        sequence.to_file(tmp_path, delimiter=":")
+        sequence.to_file(tmp_path, delimiter=':')
         with open(tmp_path, 'r') as output:
             self.assertEqual('1:2:3:4', output.readlines()[0])
 
@@ -148,8 +148,8 @@ class TestStreams(unittest.TestCase):
         self.assertEqual(expect, result)
 
     def test_to_sqlite3_failure(self):
-        insert_sql = "INSERT INTO user (id, name) VALUES (?, ?)"
-        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        insert_sql = 'INSERT INTO user (id, name) VALUES (?, ?)'
+        elements = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
         with self.assertRaises(ValueError):
             seq(elements).to_sqlite3(1, insert_sql)
 
@@ -157,87 +157,87 @@ class TestStreams(unittest.TestCase):
         tmp_path = 'functional/test/data/tmp/test.db'
 
         with sqlite3.connect(tmp_path) as conn:
-            conn.execute("DROP TABLE IF EXISTS user;")
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+            conn.execute('DROP TABLE IF EXISTS user;')
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-        insert_sql = "INSERT INTO user (id, name) VALUES (?, ?)"
-        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        insert_sql = 'INSERT INTO user (id, name) VALUES (?, ?)'
+        elements = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
 
         seq(elements).to_sqlite3(tmp_path, insert_sql)
-        result = seq.sqlite3(tmp_path, "SELECT id, name FROM user;").to_list()
+        result = seq.sqlite3(tmp_path, 'SELECT id, name FROM user;').to_list()
         self.assertListEqual(elements, result)
 
     def test_to_sqlite3_query(self):
-        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        elements = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
 
-        with sqlite3.connect(":memory:") as conn:
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+        with sqlite3.connect(':memory:') as conn:
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-            insert_sql = "INSERT INTO user (id, name) VALUES (?, ?)"
+            insert_sql = 'INSERT INTO user (id, name) VALUES (?, ?)'
             seq(elements).to_sqlite3(conn, insert_sql)
-            result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
+            result = seq.sqlite3(conn, 'SELECT id, name FROM user;').to_list()
             self.assertListEqual(elements, result)
 
     def test_to_sqlite3_tuple(self):
-        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        elements = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
 
-        with sqlite3.connect(":memory:") as conn:
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+        with sqlite3.connect(':memory:') as conn:
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-            table_name = "user"
+            table_name = 'user'
             seq(elements).to_sqlite3(conn, table_name)
-            result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
+            result = seq.sqlite3(conn, 'SELECT id, name FROM user;').to_list()
             self.assertListEqual(elements, result)
 
     def test_to_sqlite3_namedtuple(self):
-        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        elements = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
 
         # test namedtuple with the same order as column
-        with sqlite3.connect(":memory:") as conn:
-            user = collections.namedtuple("user", ["id", "name"])
+        with sqlite3.connect(':memory:') as conn:
+            user = collections.namedtuple('user', ['id', 'name'])
 
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-            table_name = "user"
+            table_name = 'user'
             seq(elements).map(lambda u: user(u[0], u[1])).to_sqlite3(conn, table_name)
-            result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
+            result = seq.sqlite3(conn, 'SELECT id, name FROM user;').to_list()
             self.assertListEqual(elements, result)
 
         # test namedtuple with different order
-        with sqlite3.connect(":memory:") as conn:
-            user = collections.namedtuple("user", ["name", "id"])
+        with sqlite3.connect(':memory:') as conn:
+            user = collections.namedtuple('user', ['name', 'id'])
 
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-            table_name = "user"
+            table_name = 'user'
             seq(elements).map(lambda u: user(u[1], u[0])).to_sqlite3(conn, table_name)
-            result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
+            result = seq.sqlite3(conn, 'SELECT id, name FROM user;').to_list()
             self.assertListEqual(elements, result)
 
     def test_to_sqlite3_dict(self):
-        elements = [(1, "Tom"), (2, "Jack"), (3, "Jane"), (4, "Stephan")]
+        elements = [(1, 'Tom'), (2, 'Jack'), (3, 'Jane'), (4, 'Stephan')]
 
-        with sqlite3.connect(":memory:") as conn:
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+        with sqlite3.connect(':memory:') as conn:
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-            table_name = "user"
-            seq(elements).map(lambda x: {"id": x[0], "name": x[1]}).to_sqlite3(conn, table_name)
-            result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
+            table_name = 'user'
+            seq(elements).map(lambda x: {'id': x[0], 'name': x[1]}).to_sqlite3(conn, table_name)
+            result = seq.sqlite3(conn, 'SELECT id, name FROM user;').to_list()
             self.assertListEqual(elements, result)
 
     def test_to_sqlite3_typerror(self):
         elements = [1, 2, 3]
-        with sqlite3.connect(":memory:") as conn:
-            conn.execute("CREATE TABLE user (id INT, name TEXT);")
+        with sqlite3.connect(':memory:') as conn:
+            conn.execute('CREATE TABLE user (id INT, name TEXT);')
             conn.commit()
 
-            table_name = "user"
+            table_name = 'user'
             with self.assertRaises(TypeError):
                 seq(elements).to_sqlite3(conn, table_name)
 

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -185,6 +185,6 @@ class TestStreams(unittest.TestCase):
 
         # test insert into a connection
         with sqlite3.connect(tmp_path) as conn:
-            seq(elements).to_sqlite3(tmp_path, insert_sql)
+            seq(elements).to_sqlite3(conn, insert_sql)
             result = seq.sqlite3(conn, "SELECT id, name FROM user;").to_list()
             self.assertListEqual(elements, result)


### PR DESCRIPTION
Initial implementation to sqlite3.
Currently it behaves like to_csv, only accepts tuple or structure as element.
Insertion SQL must be supplied and target table must be created in advance. 

I'm still considering how to insert dict.